### PR TITLE
Fix planet zoom after movement

### DIFF
--- a/core/src/main/java/com/nerds/gamejam/ecs/component/SelectedPlanet.java
+++ b/core/src/main/java/com/nerds/gamejam/ecs/component/SelectedPlanet.java
@@ -5,15 +5,11 @@ import com.artemis.Component;
 public class SelectedPlanet extends Component {
 
     public String name;
-    public float x;
-    public float y;
     public float radius;
     public String desc;
 
-    public SelectedPlanet(String name, float x, float y, float radius, String desc) {
+    public SelectedPlanet(String name, float radius, String desc) {
         this.name = name;
-        this.x = x;
-        this.y = y;
         this.radius = radius;
         this.desc = desc;
     }

--- a/core/src/main/java/com/nerds/gamejam/ecs/system/PlanetSelectedSystem.java
+++ b/core/src/main/java/com/nerds/gamejam/ecs/system/PlanetSelectedSystem.java
@@ -18,6 +18,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.utils.Align;
 import com.nerds.gamejam.GameJam;
 import com.nerds.gamejam.ecs.component.ActorComponent;
+import com.nerds.gamejam.ecs.component.PositionComponent;
 import com.nerds.gamejam.ecs.component.SelectedPlanet;
 import com.nerds.gamejam.util.InputUtil;
 import com.nerds.gamejam.util.PositionUtil;
@@ -27,6 +28,7 @@ public class PlanetSelectedSystem extends BaseEntitySystem {
 
     public static final float ZOOM_DURATION = 1.5f;
     private ComponentMapper<SelectedPlanet> selectedPlanetComponentMapper;
+    private ComponentMapper<PositionComponent> positionComponentMapper;
     private CameraSystem cameraSystem;
     private RenderSystem renderSystem;
 
@@ -38,7 +40,7 @@ public class PlanetSelectedSystem extends BaseEntitySystem {
     private float cameraYOrigin;
 
     public PlanetSelectedSystem(PositionUtil positionUtil) {
-        super(Aspect.all(SelectedPlanet.class));
+        super(Aspect.all(SelectedPlanet.class, PositionComponent.class));
         this.positionUtil = positionUtil;
     }
 
@@ -48,13 +50,14 @@ public class PlanetSelectedSystem extends BaseEntitySystem {
         if (bag.size() > 0) {
             int entityId = bag.get(0);
             SelectedPlanet selectedPlanet = selectedPlanetComponentMapper.get(entityId);
+            PositionComponent positionComponent = positionComponentMapper.get(entityId);
 
             if (timeToZoom >= 0){
                 timeToZoom -= this.world.getDelta();
                 float progress = timeToZoom < 0 ? 1 : 1f - timeToZoom / ZOOM_DURATION;
                 cameraSystem.camera.zoom = Interpolation.linear.apply(cameraZoomOrigin, 0, progress);
-                cameraSystem.camera.position.x = Interpolation.exp10Out.apply(cameraXOrigin, selectedPlanet.x + selectedPlanet.radius * 2, progress);
-                cameraSystem.camera.position.y = Interpolation.exp10Out.apply(cameraYOrigin, selectedPlanet.y + selectedPlanet.radius, progress);
+                cameraSystem.camera.position.x = Interpolation.exp10Out.apply(cameraXOrigin, positionComponent.x + selectedPlanet.radius * 2, progress);
+                cameraSystem.camera.position.y = Interpolation.exp10Out.apply(cameraYOrigin, positionComponent.y + selectedPlanet.radius, progress);
             }
 
             cameraSystem.camera.update();

--- a/core/src/main/java/com/nerds/gamejam/gameplay/planet/PlanetFactory.java
+++ b/core/src/main/java/com/nerds/gamejam/gameplay/planet/PlanetFactory.java
@@ -61,8 +61,8 @@ public class PlanetFactory {
         }
 
         BodyComponent body = new BodyComponent(PLANET_SPIRTE_SIZE, PLANET_SPIRTE_SIZE);
-        float radius = body.width / 2 * planetScale;
-        body.physicalBody = new Circle(x + radius, y + radius, radius);
+        float planetRadius = body.width / 2 * planetScale;
+        body.physicalBody = new Circle(x + planetRadius, y + planetRadius, planetRadius);
 
         Entity worldEntity = world.createEntity();
         String planetName = nameFactory.generatePlanetName();
@@ -81,7 +81,7 @@ public class PlanetFactory {
                 .add(new FontComponent(planetName, x - 10, y - 10))
                 .add(new ClickableComponent((worldX, worldY, screenX, screenY, button) -> {
                     String desc = String.format(GameJam.gameStrings.get("planetDescription"), GameJam.gameStrings.get(finalBaseMaterial.name().toLowerCase()), GameJam.gameStrings.get(finalLandmass.name().toLowerCase()), GameJam.gameStrings.get(finalSecondaryMaterial.name().toLowerCase()));
-                    worldEntity.edit().add(new SelectedPlanet(planetName, positionComponent.x, positionComponent.y, radius, desc));
+                    worldEntity.edit().add(new SelectedPlanet(planetName, planetRadius, desc));
                     return true;
                 }));
     }

--- a/core/src/main/java/com/nerds/gamejam/gameplay/planet/PlanetFactory.java
+++ b/core/src/main/java/com/nerds/gamejam/gameplay/planet/PlanetFactory.java
@@ -70,8 +70,9 @@ public class PlanetFactory {
         Material finalBaseMaterial = baseMaterial;
         Material finalSecondaryMaterial = secondaryMaterial;
         Landmass finalLandmass = landmass;
+        PositionComponent positionComponent = new PositionComponent(x, y);
         worldEntity.edit()
-                .add(new PositionComponent(x, y))
+                .add(positionComponent)
                 .add(body)
                 .add(new PlanetComponent(angle, orbitalRadius, orbitalSpeed))
                 .add(new TextureReferenceComponent(layers))
@@ -80,7 +81,7 @@ public class PlanetFactory {
                 .add(new FontComponent(planetName, x - 10, y - 10))
                 .add(new ClickableComponent((worldX, worldY, screenX, screenY, button) -> {
                     String desc = String.format(GameJam.gameStrings.get("planetDescription"), GameJam.gameStrings.get(finalBaseMaterial.name().toLowerCase()), GameJam.gameStrings.get(finalLandmass.name().toLowerCase()), GameJam.gameStrings.get(finalSecondaryMaterial.name().toLowerCase()));
-                    worldEntity.edit().add(new SelectedPlanet(planetName, x, y, radius, desc));
+                    worldEntity.edit().add(new SelectedPlanet(planetName, positionComponent.x, positionComponent.y, radius, desc));
                     return true;
                 }));
     }


### PR DESCRIPTION
Make it so that the zoom-in on planet doesn't just always zoom to the planet's initial starting location regardless of the planet's current location